### PR TITLE
Add top-right theme toggle with dark-mode support and persistence

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,4 +2,64 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
+<script>
+  (function () {
+    var savedTheme = localStorage.getItem("theme");
+    var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var theme = savedTheme || (prefersDark ? "dark" : "light");
+    document.documentElement.setAttribute("data-theme", theme);
+  })();
+</script>
+
+<style>
+  .theme-toggle {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 30;
+    border: 1px solid #d1d5db;
+    border-radius: 999px;
+    width: 2.5rem;
+    height: 2.5rem;
+    cursor: pointer;
+    background: #fff;
+  }
+
+  [data-theme="dark"] .theme-toggle {
+    background: #1f2937;
+    border-color: #4b5563;
+  }
+
+  [data-theme="dark"] body {
+    background-color: #111827;
+    color: #e5e7eb;
+  }
+
+  [data-theme="dark"] .masthead,
+  [data-theme="dark"] .greedy-nav,
+  [data-theme="dark"] .page__footer,
+  [data-theme="dark"] .archive__item,
+  [data-theme="dark"] .sidebar {
+    background-color: #1f2937;
+    color: #e5e7eb;
+  }
+
+  [data-theme="dark"] a,
+  [data-theme="dark"] .site-title,
+  [data-theme="dark"] .greedy-nav a,
+  [data-theme="dark"] .page__footer a {
+    color: #93c5fd;
+  }
+
+  [data-theme="dark"] .toc,
+  [data-theme="dark"] pre,
+  [data-theme="dark"] code,
+  [data-theme="dark"] .notice,
+  [data-theme="dark"] .search-content {
+    background-color: #0f172a;
+    color: #e5e7eb;
+    border-color: #374151;
+  }
+</style>
+
 <!-- end custom head snippets -->

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -35,6 +35,9 @@
           </svg>
         </button>
         {% endif %}
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle theme" title="Toggle theme">
+          <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        </button>
         <button class="greedy-nav__toggle hidden" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
           <div class="navicon"></div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -11,6 +11,7 @@
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
   <script src="https://kit.fontawesome.com/4eee35f757.js"></script>
 {% endif %}
+<script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
 
 {% if site.search == true or page.layout == "search" %}
   {%- assign search_provider = site.search_provider | default: "lunr" -%}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,24 @@
+(function () {
+  function setTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+
+    var icon = document.querySelector(".theme-toggle__icon");
+    if (icon) {
+      icon.textContent = theme === "dark" ? "☀️" : "🌙";
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var toggleBtn = document.getElementById("theme-toggle");
+    if (!toggleBtn) return;
+
+    var currentTheme = document.documentElement.getAttribute("data-theme") || "light";
+    setTheme(currentTheme);
+
+    toggleBtn.addEventListener("click", function () {
+      var activeTheme = document.documentElement.getAttribute("data-theme") || "light";
+      setTheme(activeTheme === "dark" ? "light" : "dark");
+    });
+  });
+})();


### PR DESCRIPTION
### Motivation

- Provide a simple, site-wide light/dark theme toggle placed in the top-right so visitors can switch page tone quickly.
- Avoid flash-of-incorrect-theme by initializing the theme as early as possible using stored preference or system `prefers-color-scheme`.
- Persist user choice across visits using `localStorage` and reflect the choice via a `data-theme` attribute for easy CSS overrides.

### Description

- Add a toggle button in the masthead by updating `_includes/masthead.html` and placing a fixed top-right button with an icon that swaps between 🌙 and ☀️.
- Initialize theme early in `_includes/head/custom.html` with an inline script that reads `localStorage` and falls back to system preference, and add scoped CSS overrides for dark theme visuals.
- Add `assets/js/theme-toggle.js` to handle click toggling, `data-theme` updates, icon switching, and `localStorage` persistence.
- Include the new script in `_includes/scripts.html` so the toggle behavior loads on all pages.

### Testing

- `node --check assets/js/theme-toggle.js` succeeded, validating the new JS file syntax.
- Launched a temporary static server and captured a browser screenshot to validate placement and runtime behavior, which succeeded.
- `bundle exec jekyll build` was attempted but could not run because the `jekyll` executable/dependencies are not available in the environment.
- `bundle install` was attempted but failed due to networking/registry `403 Forbidden` errors in this environment, preventing a full site build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985e437488832f88a2a2f0e4a29f49)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8efebd254eb6a8f2b841dbb55e739982eca63e89. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->