### PR TITLE
Add runtime theme toggle with built-in Minimal Mistakes skins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.lock
 node_modules
 npm-debug.log*
 .idea/*
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-See [my website - GitHub page](https://github.com/krisshen/mywebsite/blob/master/_projects/website.md)
-or [my website](https://krisshen.com/projects/website/)
+# My Website
+
+This site is built with Jekyll on top of the Minimal Mistakes theme.
+
+For the full project write-up, see [my website - GitHub page](https://github.com/krisshen/mywebsite/blob/master/_projects/website.md)
+or [my website](https://krisshen.com/projects/website/).
+
+## Local Development
+
+Install the Ruby dependencies locally into `vendor/bundle`:
+
+```bash
+BUNDLE_FORCE_RUBY_PLATFORM=true bundle install --path vendor/bundle
+```
+
+Start the local server:
+
+```bash
+bundle exec jekyll serve --host 127.0.0.1 --port 4000
+```
+
+Then open [http://127.0.0.1:4000](http://127.0.0.1:4000).
+
+## Notes
+
+- `BUNDLE_FORCE_RUBY_PLATFORM=true` helps older Ruby versions avoid incompatible prebuilt native gems.
+- `vendor/` is ignored in git because it is only for local dependency installs.
+- `bundle exec jekyll serve --livereload` may fail if the livereload port is already in use.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,42 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<script>
+  (function () {
+    var storageKey = "theme";
+    var root = document.documentElement;
+    var supportsMatchMedia = typeof window.matchMedia === "function";
+    var savedTheme = null;
+
+    try {
+      savedTheme = localStorage.getItem(storageKey);
+    } catch (error) {
+      savedTheme = null;
+    }
+
+    var systemTheme = supportsMatchMedia && window.matchMedia("(prefers-color-scheme: light)").matches
+      ? "light"
+      : "dark";
+    var theme = savedTheme === "light" || savedTheme === "dark" ? savedTheme : systemTheme;
+    var href = theme === "light"
+      ? "{{ '/assets/css/light.css' | relative_url }}"
+      : "{{ '/assets/css/main.css' | relative_url }}";
+    var link = document.createElement("link");
+
+    root.setAttribute("data-theme", theme);
+    root.style.colorScheme = theme;
+
+    link.id = "theme-stylesheet";
+    link.rel = "stylesheet";
+    link.href = href;
+
+    document.head.appendChild(link);
+  })();
+</script>
+<noscript>
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+</noscript>
+<link rel="preload" as="style" href="{{ '/assets/css/light.css' | relative_url }}">
 
 <!--[if IE ]>
   <style>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -35,6 +35,9 @@
           </svg>
         </button>
         {% endif %}
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Activate light mode" aria-pressed="false" title="Activate light mode">
+          <span class="theme-toggle__icon" aria-hidden="true">☾</span>
+        </button>
         <button class="greedy-nav__toggle hidden" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
           <div class="navicon"></div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -11,6 +11,7 @@
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
   <script src="https://kit.fontawesome.com/4eee35f757.js"></script>
 {% endif %}
+<script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
 
 {% if site.search == true or page.layout == "search" %}
   {%- assign search_provider = site.search_provider | default: "lunr" -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   Free for personal and commercial use under the MIT license
   https://github.com/mmistakes/minimal-mistakes/blob/master/LICENSE
 -->
-<html lang="{{ site.locale | slice: 0,2 | default: "en" }}" class="no-js">
+<html lang="{{ site.locale | slice: 0,2 | default: "en" }}" class="no-js" data-baseurl="{{ '' | relative_url }}">
   <head>
     {% include head.html %}
     {% include head/custom.html %}

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -2,7 +2,7 @@
 title: "Project - My Website"
 toc: true
 toc_sticky: true
-last_modified_at: 2019-10-11
+last_modified_at: 2026-03-19
 ---
 
 ## Introduction
@@ -53,19 +53,21 @@ Website code is in minimal-mistakes Jekyll theme, there're 3 ways to install thi
     Because minimal-mistakes requires Jekyll and Bundler.
 3. cd to my repository's folder and run below command to get all dependencies installed:
    ```
-   bundle
-   #or bundle install
+   BUNDLE_FORCE_RUBY_PLATFORM=true bundle install --path vendor/bundle
    ```
+   - `--path vendor/bundle` keeps the gems inside the repository for local development instead of trying to write into the system Ruby gem directory.
+   - `BUNDLE_FORCE_RUBY_PLATFORM=true` helps older Ruby versions avoid incompatible prebuilt native gems and build the Ruby platform variant locally.
 4. Run following command to start up a local host:
    ```
-   bundle exec jekyll serve
+   bundle exec jekyll serve --host 127.0.0.1 --port 4000
    ```
    - or run this command to start up a live reload local host:
    ```
-   bundle exec jekyll serve --livereload
+   bundle exec jekyll serve --host 127.0.0.1 --port 4000 --livereload
    ```
    - note: if on Windows, above command may throw error asking for 'wdm', add this to .gemspec file, also
    may need to re-install Ruby eventmachine library [reference](https://stackoverflow.com/questions/30682575/unable-to-load-the-eventmachine-c-extension-to-use-the-pure-ruby-reactor)
+   - note: on some machines `--livereload` may fail if the livereload port is already in use. In that case, run the normal serve command without `--livereload`.
 5. By default, the local host will be served at: http://127.0.0.1:4000
 6. Visit local host from browser, a default page should be shown.
 

--- a/_sass/minimal-mistakes/_theme-toggle.scss
+++ b/_sass/minimal-mistakes/_theme-toggle.scss
@@ -1,0 +1,36 @@
+/* ==========================================================================
+   THEME TOGGLE
+   ========================================================================== */
+
+.theme-toggle {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-left: 0.25rem;
+  border: 1px solid rgba($primary-color, 0.18);
+  border-radius: 999px;
+  background-color: rgba($background-color, 0.92);
+  color: $primary-color;
+  cursor: pointer;
+  -webkit-transition: $global-transition;
+  transition: $global-transition;
+
+  &:hover {
+    color: $link-color-hover;
+    border-color: rgba($primary-color, 0.35);
+    background-color: mix(#fff, $background-color, 85%);
+  }
+}
+
+.theme-toggle__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}

--- a/assets/css/light.scss
+++ b/assets/css/light.scss
@@ -1,0 +1,9 @@
+---
+# Alternate compiled stylesheet for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/air";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,3 +6,4 @@
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
+@import "minimal-mistakes/theme-toggle";

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,97 @@
+(function () {
+  var storageKey = "theme";
+  var root = document.documentElement;
+  var themeStylesheets = {
+    dark: "/assets/css/main.css",
+    light: "/assets/css/light.css"
+  };
+  var mediaQuery = typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: light)")
+    : null;
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem(storageKey);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function storeTheme(theme) {
+    try {
+      localStorage.setItem(storageKey, theme);
+    } catch (error) {
+      return;
+    }
+  }
+
+  function getPreferredTheme() {
+    var storedTheme = getStoredTheme();
+
+    if (storedTheme === "light" || storedTheme === "dark") {
+      return storedTheme;
+    }
+
+    return mediaQuery && mediaQuery.matches ? "light" : "dark";
+  }
+
+  function getThemeHref(theme) {
+    return (root.getAttribute("data-baseurl") || "") + themeStylesheets[theme];
+  }
+
+  function syncToggleButton(theme) {
+    var toggleButton = document.getElementById("theme-toggle");
+    if (!toggleButton) return;
+
+    var nextTheme = theme === "light" ? "dark" : "light";
+    var icon = toggleButton.querySelector(".theme-toggle__icon");
+    var label = "Activate " + nextTheme + " mode";
+
+    toggleButton.setAttribute("aria-label", label);
+    toggleButton.setAttribute("title", label);
+    toggleButton.setAttribute("aria-pressed", String(theme === "light"));
+
+    if (icon) {
+      icon.textContent = theme === "light" ? "☀" : "☾";
+    }
+  }
+
+  function applyTheme(theme, persistTheme) {
+    var themeStylesheet = document.getElementById("theme-stylesheet");
+
+    root.setAttribute("data-theme", theme);
+    root.style.colorScheme = theme;
+
+    if (themeStylesheet) {
+      themeStylesheet.href = getThemeHref(theme);
+    }
+
+    if (persistTheme) {
+      storeTheme(theme);
+    }
+
+    syncToggleButton(theme);
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var toggleButton = document.getElementById("theme-toggle");
+    var currentTheme = root.getAttribute("data-theme") || getPreferredTheme();
+
+    applyTheme(currentTheme, false);
+
+    if (!toggleButton) return;
+
+    toggleButton.addEventListener("click", function () {
+      var activeTheme = root.getAttribute("data-theme") || "light";
+      var nextTheme = activeTheme === "light" ? "dark" : "light";
+      applyTheme(nextTheme, true);
+    });
+  });
+
+  if (mediaQuery) {
+    mediaQuery.addEventListener("change", function (event) {
+      if (getStoredTheme()) return;
+      applyTheme(event.matches ? "light" : "dark", false);
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- document the working local Jekyll setup for this repo
- add a runtime theme toggle in the masthead
- switch between prebuilt Minimal Mistakes  and  skin stylesheets instead of maintaining large custom color overrides

## Testing
- bundle exec jekyll build
- verified local preview at http://127.0.0.1:4000
