### PR TITLE
Add long-press theme picker

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,11 +13,45 @@
 
 <!-- For all browsers -->
 <script>
+  window.themeToggleConfig = {
+    defaultTheme: "{{ site.minimal_mistakes_skin | default: 'default' }}",
+    lightTheme: "air",
+    themeHrefTemplate: "{{ '/assets/css/theme-THEME.css' | relative_url }}",
+    themes: [
+      { id: "default", label: "Default", tone: "light" },
+      { id: "air", label: "Air", tone: "light" },
+      { id: "aqua", label: "Aqua", tone: "light" },
+      { id: "contrast", label: "Contrast", tone: "dark" },
+      { id: "dark", label: "Dark", tone: "dark" },
+      { id: "dirt", label: "Dirt", tone: "light" },
+      { id: "mint", label: "Mint", tone: "light" },
+      { id: "neon", label: "Neon", tone: "dark" },
+      { id: "plum", label: "Plum", tone: "dark" },
+      { id: "sunrise", label: "Sunrise", tone: "light" }
+    ]
+  };
+
   (function () {
+    var config = window.themeToggleConfig || {};
     var storageKey = "theme";
     var root = document.documentElement;
     var supportsMatchMedia = typeof window.matchMedia === "function";
+    var themes = config.themes || [];
+    var validThemes = {};
     var savedTheme = null;
+
+    themes.forEach(function (theme) {
+      validThemes[theme.id] = theme;
+    });
+
+    function normalizeTheme(theme) {
+      if (theme === "light") return config.lightTheme || "air";
+      return validThemes[theme] ? theme : null;
+    }
+
+    function getThemeTone(theme) {
+      return validThemes[theme] ? validThemes[theme].tone || "light" : "light";
+    }
 
     try {
       savedTheme = localStorage.getItem(storageKey);
@@ -26,16 +60,14 @@
     }
 
     var systemTheme = supportsMatchMedia && window.matchMedia("(prefers-color-scheme: light)").matches
-      ? "light"
-      : "dark";
-    var theme = savedTheme === "light" || savedTheme === "dark" ? savedTheme : systemTheme;
-    var href = theme === "light"
-      ? "{{ '/assets/css/light.css' | relative_url }}"
-      : "{{ '/assets/css/main.css' | relative_url }}";
+      ? (config.lightTheme || "air")
+      : (config.defaultTheme || "default");
+    var theme = normalizeTheme(savedTheme) || systemTheme;
+    var href = (config.themeHrefTemplate || "").replace("THEME", theme);
     var link = document.createElement("link");
 
     root.setAttribute("data-theme", theme);
-    root.style.colorScheme = theme;
+    root.style.colorScheme = getThemeTone(theme);
 
     link.id = "theme-stylesheet";
     link.rel = "stylesheet";
@@ -45,9 +77,9 @@
   })();
 </script>
 <noscript>
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/theme-' | append: site.minimal_mistakes_skin | append: '.css' | relative_url }}">
 </noscript>
-<link rel="preload" as="style" href="{{ '/assets/css/light.css' | relative_url }}">
+<link rel="preload" as="style" href="{{ '/assets/css/theme-air.css' | relative_url }}">
 
 <!--[if IE ]>
   <style>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -35,9 +35,24 @@
           </svg>
         </button>
         {% endif %}
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Activate light mode" aria-pressed="false" title="Activate light mode">
-          <span class="theme-toggle__icon" aria-hidden="true">☾</span>
-        </button>
+        {% assign theme_options = "default:Default,air:Air,aqua:Aqua,contrast:Contrast,dark:Dark,dirt:Dirt,mint:Mint,neon:Neon,plum:Plum,sunrise:Sunrise" | split: "," %}
+        <div class="theme-toggle-group">
+          <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="theme-menu" title="Change theme">
+            <span class="theme-toggle__icon" aria-hidden="true">☾</span>
+          </button>
+          <div id="theme-menu" class="theme-menu" hidden>
+            <p class="theme-menu__note">Click to swap themes. Hold or press ↓ to pick any skin.</p>
+            <div class="theme-menu__options" role="list">
+              {% for option in theme_options %}
+                {% assign parts = option | split: ":" %}
+                <button class="theme-menu__option" type="button" data-theme="{{ parts[0] }}" aria-pressed="false">
+                  <span class="theme-menu__swatch theme-menu__swatch--{{ parts[0] }}" aria-hidden="true"></span>
+                  <span class="theme-menu__label">{{ parts[1] }}</span>
+                </button>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
         <button class="greedy-nav__toggle hidden" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
           <div class="navicon"></div>

--- a/_sass/minimal-mistakes/_theme-toggle.scss
+++ b/_sass/minimal-mistakes/_theme-toggle.scss
@@ -2,6 +2,17 @@
    THEME TOGGLE
    ========================================================================== */
 
+.theme-toggle-group {
+  position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-left: 0.25rem;
+}
+
 .theme-toggle {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -14,7 +25,6 @@
   justify-content: center;
   width: 2.5rem;
   height: 2.5rem;
-  margin-left: 0.25rem;
   border: 1px solid rgba($primary-color, 0.18);
   border-radius: 999px;
   background-color: rgba($background-color, 0.92);
@@ -33,4 +43,123 @@
 .theme-toggle__icon {
   font-size: 1.1rem;
   line-height: 1;
+}
+
+.theme-menu {
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  right: 0;
+  z-index: 30;
+  width: min(17rem, calc(100vw - 2rem));
+  padding: 0.7rem;
+  border: 1px solid rgba($primary-color, 0.14);
+  border-radius: 1rem;
+  background: rgba($background-color, 0.96);
+  -webkit-box-shadow: 0 16px 35px rgba(#000, 0.16);
+  box-shadow: 0 16px 35px rgba(#000, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.theme-menu[hidden] {
+  display: none;
+}
+
+.theme-menu__note {
+  margin: 0 0 0.6rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: mix($text-color, $muted-text-color, 55%);
+}
+
+.theme-menu__options {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.theme-menu__option {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0.8rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  -webkit-transition: $global-transition;
+  transition: $global-transition;
+
+  &:hover,
+  &:focus {
+    border-color: rgba($primary-color, 0.2);
+    background: rgba($primary-color, 0.08);
+    outline: none;
+  }
+
+  &.is-active {
+    border-color: rgba($link-color, 0.35);
+    background: rgba($link-color, 0.12);
+  }
+}
+
+.theme-menu__label {
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+.theme-menu__swatch {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(#000, 0.12);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(#fff, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(#fff, 0.22);
+}
+
+.theme-menu__swatch--default {
+  background: linear-gradient(135deg, #f7f9fb, #8bc6ff);
+}
+
+.theme-menu__swatch--air {
+  background: linear-gradient(135deg, #ffffff, #beddf5);
+}
+
+.theme-menu__swatch--aqua {
+  background: linear-gradient(135deg, #d9fff5, #00a7a7);
+}
+
+.theme-menu__swatch--contrast {
+  background: linear-gradient(135deg, #ffffff, #111111);
+}
+
+.theme-menu__swatch--dark {
+  background: linear-gradient(135deg, #202630, #6d7f95);
+}
+
+.theme-menu__swatch--dirt {
+  background: linear-gradient(135deg, #efe0c3, #7d5e40);
+}
+
+.theme-menu__swatch--mint {
+  background: linear-gradient(135deg, #effcf5, #3eb489);
+}
+
+.theme-menu__swatch--neon {
+  background: linear-gradient(135deg, #0f1720, #6aff9d);
+}
+
+.theme-menu__swatch--plum {
+  background: linear-gradient(135deg, #291936, #dba4ff);
+}
+
+.theme-menu__swatch--sunrise {
+  background: linear-gradient(135deg, #ffe2c3, #ff7b54);
 }

--- a/assets/css/theme-air.scss
+++ b/assets/css/theme-air.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes air skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/air";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-aqua.scss
+++ b/assets/css/theme-aqua.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes aqua skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/aqua";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-contrast.scss
+++ b/assets/css/theme-contrast.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes contrast skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/contrast";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-dark.scss
+++ b/assets/css/theme-dark.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes dark skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/dark";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-default.scss
+++ b/assets/css/theme-default.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes default skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/default";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-dirt.scss
+++ b/assets/css/theme-dirt.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes dirt skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/dirt";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-mint.scss
+++ b/assets/css/theme-mint.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes mint skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/mint";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-neon.scss
+++ b/assets/css/theme-neon.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes neon skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/neon";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-plum.scss
+++ b/assets/css/theme-plum.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes plum skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/plum";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/css/theme-sunrise.scss
+++ b/assets/css/theme-sunrise.scss
@@ -1,0 +1,9 @@
+---
+# Minimal Mistakes sunrise skin for runtime theme switching
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/sunrise";
+@import "minimal-mistakes";
+@import "minimal-mistakes/theme-toggle";

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,97 +1,285 @@
 (function () {
-  var storageKey = "theme";
+  var themeStorageKey = "theme";
+  var alternateThemeStorageKey = "theme-alternate";
   var root = document.documentElement;
-  var themeStylesheets = {
-    dark: "/assets/css/main.css",
-    light: "/assets/css/light.css"
-  };
+  var config = window.themeToggleConfig || {};
+  var themeHrefTemplate = config.themeHrefTemplate || "";
+  var defaultTheme = config.defaultTheme || "default";
+  var lightTheme = config.lightTheme || "air";
+  var themes = config.themes || [];
+  var validThemes = {};
+  var themeMeta = {};
   var mediaQuery = typeof window.matchMedia === "function"
     ? window.matchMedia("(prefers-color-scheme: light)")
     : null;
+  var longPressDelay = 420;
+  var longPressTimer = null;
+  var longPressTriggered = false;
+  var alternateTheme = null;
 
-  function getStoredTheme() {
+  themes.forEach(function (theme) {
+    validThemes[theme.id] = true;
+    themeMeta[theme.id] = theme;
+  });
+
+  function normalizeTheme(theme) {
+    if (theme === "light") return lightTheme;
+    return validThemes[theme] ? theme : null;
+  }
+
+  function getThemeLabel(theme) {
+    return themeMeta[theme] ? themeMeta[theme].label : theme;
+  }
+
+  function getThemeTone(theme) {
+    return themeMeta[theme] ? themeMeta[theme].tone || "light" : "light";
+  }
+
+  function getStoredValue(key) {
     try {
-      return localStorage.getItem(storageKey);
+      return localStorage.getItem(key);
     } catch (error) {
       return null;
     }
   }
 
-  function storeTheme(theme) {
+  function storeValue(key, value) {
     try {
-      localStorage.setItem(storageKey, theme);
+      localStorage.setItem(key, value);
     } catch (error) {
       return;
     }
   }
 
-  function getPreferredTheme() {
-    var storedTheme = getStoredTheme();
+  function getStoredTheme() {
+    return normalizeTheme(getStoredValue(themeStorageKey));
+  }
 
-    if (storedTheme === "light" || storedTheme === "dark") {
-      return storedTheme;
+  function getStoredAlternateTheme() {
+    return normalizeTheme(getStoredValue(alternateThemeStorageKey));
+  }
+
+  function getSystemTheme() {
+    return mediaQuery && mediaQuery.matches ? lightTheme : defaultTheme;
+  }
+
+  function inferAlternateTheme(theme) {
+    if (theme === lightTheme) {
+      return defaultTheme !== lightTheme ? defaultTheme : "dark";
     }
 
-    return mediaQuery && mediaQuery.matches ? "light" : "dark";
+    return lightTheme;
+  }
+
+  function getPreferredTheme() {
+    return getStoredTheme() || getSystemTheme();
   }
 
   function getThemeHref(theme) {
-    return (root.getAttribute("data-baseurl") || "") + themeStylesheets[theme];
+    return themeHrefTemplate.replace("THEME", theme);
   }
 
-  function syncToggleButton(theme) {
+  function getActiveTheme() {
+    return normalizeTheme(root.getAttribute("data-theme")) || getPreferredTheme();
+  }
+
+  function syncThemeMenu(theme) {
+    var themeOptions = document.querySelectorAll(".theme-menu__option");
+
+    Array.prototype.forEach.call(themeOptions, function (themeOption) {
+      var isActive = themeOption.getAttribute("data-theme") === theme;
+
+      themeOption.classList.toggle("is-active", isActive);
+      themeOption.setAttribute("aria-pressed", String(isActive));
+    });
+  }
+
+  function syncToggleButton(theme, menuOpen) {
     var toggleButton = document.getElementById("theme-toggle");
     if (!toggleButton) return;
 
-    var nextTheme = theme === "light" ? "dark" : "light";
+    var nextTheme = normalizeTheme(alternateTheme) || inferAlternateTheme(theme);
     var icon = toggleButton.querySelector(".theme-toggle__icon");
-    var label = "Activate " + nextTheme + " mode";
+    var label = "Click to switch to " + getThemeLabel(nextTheme) + ". Hold or press down arrow to pick a theme.";
 
     toggleButton.setAttribute("aria-label", label);
     toggleButton.setAttribute("title", label);
-    toggleButton.setAttribute("aria-pressed", String(theme === "light"));
+    toggleButton.setAttribute("aria-expanded", String(Boolean(menuOpen)));
 
     if (icon) {
-      icon.textContent = theme === "light" ? "☀" : "☾";
+      icon.textContent = getThemeTone(theme) === "dark" ? "☾" : "☀";
     }
   }
 
-  function applyTheme(theme, persistTheme) {
-    var themeStylesheet = document.getElementById("theme-stylesheet");
+  function persistThemeSelection(theme) {
+    storeValue(themeStorageKey, theme);
+    storeValue(alternateThemeStorageKey, alternateTheme);
+  }
 
-    root.setAttribute("data-theme", theme);
-    root.style.colorScheme = theme;
+  function applyTheme(theme, options) {
+    var settings = options || {};
+    var themeStylesheet = document.getElementById("theme-stylesheet");
+    var nextTheme = normalizeTheme(theme) || getPreferredTheme();
+
+    root.setAttribute("data-theme", nextTheme);
+    root.style.colorScheme = getThemeTone(nextTheme);
 
     if (themeStylesheet) {
-      themeStylesheet.href = getThemeHref(theme);
+      themeStylesheet.href = getThemeHref(nextTheme);
     }
 
-    if (persistTheme) {
-      storeTheme(theme);
+    if (settings.persistTheme) {
+      persistThemeSelection(nextTheme);
     }
 
-    syncToggleButton(theme);
+    syncThemeMenu(nextTheme);
+    syncToggleButton(nextTheme, settings.menuOpen);
+  }
+
+  function openThemeMenu(shouldFocusActiveTheme) {
+    var themeMenu = document.getElementById("theme-menu");
+    var activeThemeButton;
+
+    if (!themeMenu || !themeMenu.hidden) return;
+
+    themeMenu.hidden = false;
+    syncToggleButton(getActiveTheme(), true);
+
+    if (shouldFocusActiveTheme !== false) {
+      activeThemeButton = themeMenu.querySelector(".theme-menu__option.is-active") || themeMenu.querySelector(".theme-menu__option");
+      if (activeThemeButton) activeThemeButton.focus();
+    }
+  }
+
+  function closeThemeMenu(shouldFocusToggle) {
+    var themeMenu = document.getElementById("theme-menu");
+    var toggleButton = document.getElementById("theme-toggle");
+
+    if (!themeMenu || themeMenu.hidden) return;
+
+    themeMenu.hidden = true;
+    syncToggleButton(getActiveTheme(), false);
+
+    if (shouldFocusToggle && toggleButton) {
+      toggleButton.focus();
+    }
+  }
+
+  function toggleQuickTheme() {
+    var currentTheme = getActiveTheme();
+    var nextTheme = normalizeTheme(alternateTheme) || inferAlternateTheme(currentTheme);
+
+    alternateTheme = currentTheme;
+    applyTheme(nextTheme, { persistTheme: true, menuOpen: false });
+  }
+
+  function selectTheme(theme) {
+    var currentTheme = getActiveTheme();
+    var nextTheme = normalizeTheme(theme);
+
+    if (!nextTheme) return;
+
+    if (nextTheme !== currentTheme) {
+      alternateTheme = currentTheme;
+    } else if (!alternateTheme) {
+      alternateTheme = inferAlternateTheme(nextTheme);
+    }
+
+    applyTheme(nextTheme, { persistTheme: true, menuOpen: true });
+    closeThemeMenu(true);
+  }
+
+  function clearLongPressTimer() {
+    if (!longPressTimer) return;
+    window.clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+
+  function startLongPress(event) {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+
+    clearLongPressTimer();
+    longPressTriggered = false;
+    longPressTimer = window.setTimeout(function () {
+      longPressTriggered = true;
+      openThemeMenu(false);
+    }, longPressDelay);
   }
 
   document.addEventListener("DOMContentLoaded", function () {
     var toggleButton = document.getElementById("theme-toggle");
-    var currentTheme = root.getAttribute("data-theme") || getPreferredTheme();
+    var themeMenu = document.getElementById("theme-menu");
+    var currentTheme = normalizeTheme(root.getAttribute("data-theme")) || getPreferredTheme();
 
-    applyTheme(currentTheme, false);
+    alternateTheme = getStoredAlternateTheme() || inferAlternateTheme(currentTheme);
+    applyTheme(currentTheme, { persistTheme: false, menuOpen: false });
 
     if (!toggleButton) return;
 
-    toggleButton.addEventListener("click", function () {
-      var activeTheme = root.getAttribute("data-theme") || "light";
-      var nextTheme = activeTheme === "light" ? "dark" : "light";
-      applyTheme(nextTheme, true);
+    toggleButton.addEventListener("pointerdown", startLongPress);
+
+    ["pointerup", "pointerleave", "pointercancel"].forEach(function (eventName) {
+      toggleButton.addEventListener(eventName, clearLongPressTimer);
+    });
+
+    toggleButton.addEventListener("contextmenu", function (event) {
+      event.preventDefault();
+      clearLongPressTimer();
+      openThemeMenu();
+    });
+
+    toggleButton.addEventListener("keydown", function (event) {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        openThemeMenu();
+      }
+
+      if (event.key === "Escape") {
+        closeThemeMenu(false);
+      }
+    });
+
+    toggleButton.addEventListener("click", function (event) {
+      if (longPressTriggered) {
+        longPressTriggered = false;
+        event.preventDefault();
+        return;
+      }
+
+      toggleQuickTheme();
+    });
+
+    if (themeMenu) {
+      themeMenu.addEventListener("click", function (event) {
+        var themeOption = event.target.closest(".theme-menu__option");
+        if (!themeOption) return;
+        selectTheme(themeOption.getAttribute("data-theme"));
+      });
+
+      themeMenu.addEventListener("keydown", function (event) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu(true);
+        }
+      });
+    }
+
+    document.addEventListener("click", function (event) {
+      var insideMenu = themeMenu && themeMenu.contains(event.target);
+      var onToggle = toggleButton.contains(event.target);
+
+      if (!insideMenu && !onToggle) {
+        closeThemeMenu(false);
+      }
     });
   });
 
   if (mediaQuery) {
     mediaQuery.addEventListener("change", function (event) {
       if (getStoredTheme()) return;
-      applyTheme(event.matches ? "light" : "dark", false);
+
+      alternateTheme = inferAlternateTheme(event.matches ? lightTheme : defaultTheme);
+      applyTheme(event.matches ? lightTheme : defaultTheme, { persistTheme: false, menuOpen: false });
     });
   }
 })();


### PR DESCRIPTION
## Summary
- turn the theme toggle into a quick switch plus a long-press theme picker
- add per-skin stylesheet entrypoints for the vendored Minimal Mistakes skins
- keep the control usable with keyboard and right-click fallbacks

## Testing
- bundle exec jekyll build
- bundle exec jekyll serve --host 127.0.0.1 --port 4000
