### PR TITLE
ci: add auto-build workflow for paper-radar on data changes

### DIFF
--- a/.github/workflows/build-paper-radar.yml
+++ b/.github/workflows/build-paper-radar.yml
@@ -1,0 +1,40 @@
+name: Build Paper Radar on Data Changes
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - '_paper-radar-source/data/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      
+      - name: Install dependencies
+        working-directory: _paper-radar-source
+        run: npm ci
+      
+      - name: Build
+        working-directory: _paper-radar-source
+        run: npm run build
+      
+      - name: Copy built assets to paper-radar folder
+        run: |
+          rm -rf paper-radar/*
+          cp -r _paper-radar-source/out/* paper-radar/
+      
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add paper-radar/
+          git commit -m "chore: rebuild paper-radar assets" -a || true
+          git push


### PR DESCRIPTION
## Description
Adds a GitHub Action workflow that automatically builds the Paper Radar application and deploys assets whenever data files change.

## What's included
- **Trigger**: Activates on push to `master` or `main` when `_paper-radar-source/data/**` files change
- **Build**: Runs `npm run build` in the `_paper-radar-source` directory
- **Deploy**: Copies built assets from `out/` folder to `paper-radar/` folder
- **Auto-commit**: Automatically commits and pushes the updated assets

## Workflow file
- `.github/workflows/build-paper-radar.yml`