### PR TITLE
Fix: Improve mobile UI for PaperCard component

### DIFF
--- a/.github/workflows/build-paper-radar.yml
+++ b/.github/workflows/build-paper-radar.yml
@@ -9,6 +9,7 @@ on:
       - '_paper-radar-source/data/**'
       - '_paper-radar-source/components/**'
       - '_paper-radar-source/app/**'
+      - '_paper-radar-source/contexts/**'
 
 jobs:
   build:

--- a/.github/workflows/build-paper-radar.yml
+++ b/.github/workflows/build-paper-radar.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '_paper-radar-source/data/**'
       - '_paper-radar-source/components/**'
+      - '_paper-radar-source/app/**'
 
 jobs:
   build:

--- a/.github/workflows/build-paper-radar.yml
+++ b/.github/workflows/build-paper-radar.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - '_paper-radar-source/data/**'
+      - '_paper-radar-source/components/**'
 
 jobs:
   build:

--- a/_paper-radar-source/components/PaperCard.tsx
+++ b/_paper-radar-source/components/PaperCard.tsx
@@ -103,21 +103,21 @@ export default function PaperCard({ paper, globalMode }: PaperCardProps) {
 
             <div className="p-6 sm:p-8">
                 {/* Header row */}
-                <div className="flex items-start justify-between gap-4 mb-5">
-                    <div className="flex items-start gap-4">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 mb-5">
+                    <div className="flex flex-col sm:flex-row sm:items-start gap-3 sm:gap-4">
                         {/* Issue number */}
                         <span
                             className="
-                text-4xl font-bold leading-none select-none
+                text-2xl sm:text-4xl font-bold leading-none select-none
                 text-[#e8e8e6] group-hover:text-[#f0d0cd]
                 transition-colors duration-300
-                font-serif shrink-0 mt-1
+                font-serif shrink-0 sm:mt-1
               "
                             style={{ fontFamily: 'Georgia, serif' }}
                         >
                             {paper.id}
                         </span>
-                        <div>
+                        <div className="flex-1">
                             <h2
                                 className="text-lg sm:text-xl font-semibold text-[#1a1a1a] leading-snug mb-1"
                                 style={{ fontFamily: 'Georgia, serif' }}
@@ -130,7 +130,7 @@ export default function PaperCard({ paper, globalMode }: PaperCardProps) {
                         </div>
                     </div>
                     {/* Star rating */}
-                    <div className="shrink-0 mt-1">
+                    <div className="shrink-0 sm:mt-1">
                         <StarRating score={paper.recommendationScore} />
                     </div>
                 </div>


### PR DESCRIPTION
## Problem
Mobile UI was cramped with awkward text wrapping on the PaperCard component. The header layout was not responsive, causing the paper ID and title to overlap and wrap poorly on small screens.

## Solution
Made the header layout responsive with the following changes:
- **Responsive layout**: Header now stacks vertically on mobile (`flex-col`) and horizontally on larger screens (`sm:flex-row`)
- **Scaled typography**: Paper ID reduced to `text-2xl` on mobile, scales to `text-4xl` on larger screens
- **Better space utilization**: Added `flex-1` to title container for proper expansion on mobile
- **Optimized spacing**: Tighter gaps on mobile (`gap-3`) expanding to (`sm:gap-4`) on desktop
- **Fixed positioning**: Star rating positioning improved to prevent wrapping

## Testing
- Tested on mobile viewport (responsive design mode)
- Layout now correctly stacks and wraps content
- Typography scales appropriately for smaller screens
- All elements properly aligned and spaced